### PR TITLE
FG-115: Support 2 lines content as part of status-label

### DIFF
--- a/projects/fusion-ui/components/status-label/v3/status-label.component.scss
+++ b/projects/fusion-ui/components/status-label/v3/status-label.component.scss
@@ -14,22 +14,33 @@
         gap: 8px;
 
         svg {
-            @include size(8px);
+            @include size(var(--fu-status-label-size, 8px));
+        }
+
+        &:not(.fu-flat) {
+            svg * {
+                stroke: var(--fu-status-label-color, $fu-primary-500);
+            }
+        }
+        &.fu-flat {
+            svg * {
+                fill: var(--fu-status-label-color, $fu-primary-500);
+            }
         }
 
         @extend %font-bodySmall;
-        color: $fu-black-500;
+        color: var(--fu-status-label-text-color, $fu-black-500);;
 
         &.archived {
             &:not(.fu-flat) {
                 svg * {
-                    stroke: $fu-light-500;
+                    stroke: var(--fu-status-label-archived, $fu-light-500);
                 }
             }
 
             &.fu-flat {
                 svg * {
-                    fill: $fu-light-500;
+                    fill: var(--fu-status-label-archived, $fu-light-500);
                 }
             }
         }
@@ -37,13 +48,13 @@
         &.disabled {
             &:not(.fu-flat) {
                 svg * {
-                    stroke: $fu-light-900;
+                    stroke: var(--fu-status-label-disabled, $fu-light-900);
                 }
             }
 
             &.fu-flat {
                 svg * {
-                    fill: $fu-light-900;
+                    fill: var(--fu-status-label-disabled, $fu-light-900);
                 }
             }
         }
@@ -51,13 +62,13 @@
         &.warning {
             &:not(.fu-flat) {
                 svg * {
-                    stroke: $fu-neutral-500;
+                    stroke: var(--fu-status-label-warning, $fu-neutral-500);
                 }
             }
 
             &.fu-flat {
                 svg * {
-                    fill: $fu-neutral-500;
+                    fill: var(--fu-status-label-warning, $fu-neutral-500);
                 }
             }
         }
@@ -65,13 +76,13 @@
         &.error {
             &:not(.fu-flat) {
                 svg * {
-                    stroke: $fu-negative-500;
+                    stroke: var(--fu-status-label-error, $fu-negative-500);
                 }
             }
 
             &.fu-flat {
                 svg * {
-                    fill: $fu-negative-500;
+                    fill: var(--fu-status-label-error, $fu-negative-500);
                 }
             }
         }
@@ -79,13 +90,13 @@
         &.success {
             &:not(.fu-flat) {
                 svg * {
-                    stroke: $fu-positive-500;
+                    stroke: var(--fu-status-label-success, $fu-positive-500);
                 }
             }
 
             &.fu-flat {
                 svg * {
-                    fill: $fu-positive-500;
+                    fill: var(--fu-status-label-success, $fu-positive-500);
                 }
             }
         }
@@ -93,7 +104,7 @@
 
     &.fu-large {
         .fu-status-label-wrapper svg {
-            @include size(12px);
+            @include size(var(--fu-status-label-large-size, 12px));
         }
     }
 }

--- a/projects/fusion-ui/components/status-label/v3/status-label.component.stories.ts
+++ b/projects/fusion-ui/components/status-label/v3/status-label.component.stories.ts
@@ -1,0 +1,107 @@
+import {Story, Meta} from '@storybook/angular';
+import {moduleMetadata} from '@storybook/angular';
+import {CommonModule} from '@angular/common';
+import {dedent} from 'ts-dedent';
+import {StatusLabelComponent} from './status-label.component';
+
+export default {
+    title: 'Components/Stats Label',
+    component: StatusLabelComponent,
+    decorators: [
+        moduleMetadata({
+            declarations: [],
+            imports: [CommonModule]
+        })
+    ],
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component: dedent`**StatusLabelComponent component**
+
+                has css variables for change colors as you want:
+                * **--fu-status-label-text-color**:  default text color (#53575B)
+                * **--fu-status-label-color**:  default icon color (#3083FF)
+
+                also you can set statuses colors to custom:
+                * **--fu-status-label-archived** (#D2D5D8)
+                * **--fu-status-label-disabled** (#7B838C)
+                * **--fu-status-label-warning** (#FFB424)
+                * **--fu-status-label-error** (#FF6A63)
+                * **--fu-status-label-success** (#22C891)
+
+                size:
+                * **--fu-status-label-size** (8px)
+                * **--fu-status-label-large-size** (12px)
+                `
+            }
+        },
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/V4eZU3qDgKYPhR4eaTvSwy/%F0%9F%8E%A8-Style-guide-2021-Master?node-id=12029%3A115705&t=ThHtp6fTBWEAzj7R-1'
+        }
+    },
+    args: {
+        label: 'Text Label',
+        helper: 'helper text'
+    }
+} as Meta<StatusLabelComponent>;
+
+const StatusLabelTemplate: Story<StatusLabelComponent> = (args: StatusLabelComponent) => ({
+    props: {...args}
+});
+
+// region Default
+export const Default = StatusLabelTemplate.bind({});
+// endregion
+
+// region WithLabel
+const StatusLabelWithLabelTemplate: Story<StatusLabelComponent> = (args: StatusLabelComponent) => ({
+    props: {...args},
+    template: `<fusion-status-label
+  [status]="status"
+  [flat]="true"
+>
+  {{label}}
+</fusion-status-label>`
+});
+export const WithLabel = StatusLabelWithLabelTemplate.bind({});
+WithLabel.parameters = {
+    docs: {
+        description: {
+            story: `For label - just add text inside:
+        \`<fusion-status-label>Text Label</fusion-status-label>\`
+`
+        }
+    }
+};
+// endregion
+
+// region WithTwoLines
+const StatusLabelWithTwoLinesTemplate: Story<StatusLabelComponent> = (args: StatusLabelComponent) => ({
+    props: {...args},
+    template: `<fusion-status-label
+  [status]="status"
+  [flat]="true"
+>
+  <div>
+    <div>{{label}}</div>
+    <div class="font-bodyXSmall" style="color: #7B838C">{{helper}}</div>
+  </div>
+</fusion-status-label>`
+});
+export const WithTwoLines = StatusLabelWithTwoLinesTemplate.bind({});
+WithTwoLines.parameters = {
+    docs: {
+        description: {
+            story: `You can add any inner content: \`<fusion-status-label [flat]="true">
+  <div>
+    <div>Test Label</div>
+    <div class="font-bodyXSmall" style="color: #7B838C">helper text</div>
+  </div>
+</fusion-status-label>\`
+`
+        }
+    }
+};
+// endregion

--- a/projects/fusion-ui/components/status-label/v3/status-label.entity.ts
+++ b/projects/fusion-ui/components/status-label/v3/status-label.entity.ts
@@ -5,3 +5,4 @@ export enum StatusLabelType {
     Archived = 'archived', // Light-500
     Disabled = 'disabled' // Light-900
 }
+// default - Primary-500


### PR DESCRIPTION
Added support for any content and CSS variables  for color and size customization